### PR TITLE
Update CLI name to eks-review

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Esto creará un ejecutable llamado `eks-review` en el directorio actual.
 
 💡 **Uso**  
 Asegúrate de que tu kubeconfig esté configurado correctamente para apuntar a tu clúster de Kubernetes (Minikube, EKS, GKE, etc.).  
-Por defecto, eks-review-cli leerá tu kubeconfig en `~/.kube/config`.
+Por defecto, `eks-review` leerá tu kubeconfig en `~/.kube/config`.
 
 Para una lista completa y detallada de todos los comandos, sus subcomandos y todas sus opciones, por favor consulta la Referencia de Comandos en [COMMANDS.md](./COMMANDS.md).
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,7 +10,7 @@ import (
 var Verbose bool // Exportada para ser accesible por otros archivos del paquete cmd
 
 var rootCmd = &cobra.Command{
-	Use:   "eks-review-cli",
+	Use:   "eks-review",
 	Short: "Una herramienta CLI para revisar clústeres de EKS.",
 	Long: `eks-review-cli es una herramienta de línea de comandos (CLI) escrita en Go, 
 diseñada para simplificar la revisión y el diagnóstico de recursos en clústeres de Kubernetes, 


### PR DESCRIPTION
## Summary
- unify the binary name as `eks-review`
- update `cmd/root.go`'s command usage
- fix README to mention the `eks-review` binary

## Testing
- `gofmt -w cmd/root.go`
- `go list ./...` *(fails: proxy blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6859e2821878832b8bf549a46f695991