### PR TITLE
Improve command descriptions

### DIFF
--- a/cmd/diagnose.go
+++ b/cmd/diagnose.go
@@ -9,13 +9,9 @@ import (
 // diagnoseCmd represents the diagnose command
 var diagnoseCmd = &cobra.Command{
 	Use:   "diagnose",
-	Short: "A brief description of your command",
-	Long: `A longer description that spans multiple lines and likely contains examples
-and usage of using your command. For example:
-
-Cobra is a CLI library for Go that empowers applications.
-This application is a tool to generate the needed files
-to quickly create a Cobra application.`,
+	Short: "Utilidades de diagnóstico",
+	Long: `Revisa el estado de componentes del clúster
+y ayuda a localizar fallas o inconsistencias en los recursos.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println("diagnose called")
 	},
@@ -23,14 +19,4 @@ to quickly create a Cobra application.`,
 
 func init() {
 	rootCmd.AddCommand(diagnoseCmd)
-
-	// Here you will define your flags and configuration settings.
-
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// diagnoseCmd.PersistentFlags().String("foo", "", "A help for foo")
-
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// diagnoseCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }

--- a/cmd/monitor.go
+++ b/cmd/monitor.go
@@ -9,13 +9,10 @@ import (
 // monitorCmd represents the monitor command
 var monitorCmd = &cobra.Command{
 	Use:   "monitor",
-	Short: "A brief description of your command",
-	Long: `A longer description that spans multiple lines and likely contains examples
-and usage of using your command. For example:
-
-Cobra is a CLI library for Go that empowers applications.
-This application is a tool to generate the needed files
-to quickly create a Cobra application.`,
+	Short: "Herramientas de monitoreo del clúster",
+	Long: `Agrupa subcomandos orientados a la observación y seguimiento del estado
+del clúster de Kubernetes.
+Permite revisar métricas y eventos para detectar problemas de forma temprana.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println("monitor called")
 	},
@@ -23,14 +20,4 @@ to quickly create a Cobra application.`,
 
 func init() {
 	rootCmd.AddCommand(monitorCmd)
-
-	// Here you will define your flags and configuration settings.
-
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// monitorCmd.PersistentFlags().String("foo", "", "A help for foo")
-
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// monitorCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }

--- a/cmd/optimize.go
+++ b/cmd/optimize.go
@@ -9,13 +9,9 @@ import (
 // optimizeCmd represents the optimize command
 var optimizeCmd = &cobra.Command{
 	Use:   "optimize",
-	Short: "A brief description of your command",
-	Long: `A longer description that spans multiple lines and likely contains examples
-and usage of using your command. For example:
-
-Cobra is a CLI library for Go that empowers applications.
-This application is a tool to generate the needed files
-to quickly create a Cobra application.`,
+	Short: "Recomendaciones para optimizar recursos",
+	Long: `Ejecuta análisis sobre el uso de recursos del clúster
+y propone ajustes para mejorar el rendimiento y reducir costos.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println("optimize called")
 	},
@@ -23,14 +19,4 @@ to quickly create a Cobra application.`,
 
 func init() {
 	rootCmd.AddCommand(optimizeCmd)
-
-	// Here you will define your flags and configuration settings.
-
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// optimizeCmd.PersistentFlags().String("foo", "", "A help for foo")
-
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// optimizeCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }

--- a/cmd/security.go
+++ b/cmd/security.go
@@ -9,13 +9,9 @@ import (
 // securityCmd represents the security command
 var securityCmd = &cobra.Command{
 	Use:   "security",
-	Short: "A brief description of your command",
-	Long: `A longer description that spans multiple lines and likely contains examples
-and usage of using your command. For example:
-
-Cobra is a CLI library for Go that empowers applications.
-This application is a tool to generate the needed files
-to quickly create a Cobra application.`,
+	Short: "Comandos para verificar seguridad",
+	Long: `Ejecuta revisiones de políticas, permisos y configuraciones
+que afectan la seguridad del clúster de Kubernetes.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println("security called")
 	},
@@ -23,14 +19,4 @@ to quickly create a Cobra application.`,
 
 func init() {
 	rootCmd.AddCommand(securityCmd)
-
-	// Here you will define your flags and configuration settings.
-
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// securityCmd.PersistentFlags().String("foo", "", "A help for foo")
-
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// securityCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }


### PR DESCRIPTION
## Summary
- add Spanish descriptions for monitor, optimize, security and diagnose commands
- remove leftover scaffolded comments
- run gofmt

## Testing
- `go test ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6859eb134b94832b934046f10ce2a28c