### PR TITLE
Fix PrintBasicTable format output

### DIFF
--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -114,15 +114,15 @@ func PrintBasicTable(headers []string, rows [][]string) {
 	for i, h := range headers {
 		headerArgs[i] = h
 	}
-	fmt.Printf(formatString, headerArgs...)
-	fmt.Printf(separator)
+	fmt.Print(fmt.Sprintf(formatString, headerArgs...))
+	fmt.Print(separator)
 
 	for _, row := range rows {
 		rowArgs := make([]interface{}, len(row))
 		for i, cell := range row {
 			rowArgs[i] = cell
 		}
-		fmt.Printf(formatString, rowArgs...)
+		fmt.Print(fmt.Sprintf(formatString, rowArgs...))
 	}
 	fmt.Println()
 }


### PR DESCRIPTION
## Summary
- adjust format printing in `cmd/utils.go`
- use fmt.Sprintf with fmt.Print

## Testing
- `go test ./...` *(fails: forbidden; module downloads blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6859f031acb4832bba7a61f048b46efc