### PR TITLE
Standardize binary name

### DIFF
--- a/INSTALLATION_ADVANCED.md
+++ b/INSTALLATION_ADVANCED.md
@@ -1,31 +1,31 @@
-# Instalación Avanzada y Acceso Global a `kcli`
+# Instalación Avanzada y Acceso Global a `eks-review`
 
-Esta guía explica cómo compilar tu herramienta CLI con el nombre `kcli` y cómo instalarla para que puedas ejecutarla directamente desde cualquier ubicación en tu terminal, sin necesidad de navegar a su directorio de código fuente o usar `./kcli`.
+Esta guía explica cómo compilar tu herramienta CLI con el nombre `eks-review` y cómo instalarla para que puedas ejecutarla directamente desde cualquier ubicación en tu terminal, sin necesidad de navegar a su directorio de código fuente o usar `./eks-review`.
 
 ---
 
 ## 1. Cambiar el Nombre del Ejecutable Durante la Compilación
 
-Por defecto, al compilar tu proyecto, el nombre del ejecutable podría basarse en el nombre del directorio o del módulo. Para asegurarte de que el binario se llame `kcli`, usa la opción `-o`:
+Por defecto, al compilar tu proyecto, el nombre del ejecutable podría basarse en el nombre del directorio o del módulo. Para asegurarte de que el binario se llame `eks-review`, usa la opción `-o`:
 
 ```bash
-go build -o kcli
+go build -o eks-review
 ```
 
-Esto generará un archivo ejecutable llamado `kcli` (o `kcli.exe` en Windows) en el directorio actual del proyecto.
+Esto generará un archivo ejecutable llamado `eks-review` (o `eks-review.exe` en Windows) en el directorio actual del proyecto.
 
 ---
 
-## 2. Instalar `kcli` para Acceso Global
+## 2. Instalar `eks-review` para Acceso Global
 
-Para ejecutar `kcli` desde cualquier lugar, el archivo ejecutable debe estar ubicado en un directorio que esté listado en la variable de entorno `PATH` de tu sistema.
+Para ejecutar `eks-review` desde cualquier lugar, el archivo ejecutable debe estar ubicado en un directorio que esté listado en la variable de entorno `PATH` de tu sistema.
 
 ### Opción A: Instalación Manual (Recomendada)
 
-1. **Compila `kcli`:**
+1. **Compila `eks-review`:**
 
     ```bash
-    go build -o kcli
+    go build -o eks-review
     ```
 
 2. **Mueve el ejecutable a un directorio en tu `PATH`:**
@@ -34,22 +34,22 @@ Para ejecutar `kcli` desde cualquier lugar, el archivo ejecutable debe estar ubi
         - Un directorio común es `/usr/local/bin` (requiere permisos de superusuario):
 
             ```bash
-            sudo mv kcli /usr/local/bin/
+            sudo mv eks-review /usr/local/bin/
             ```
 
         - Alternativamente, puedes usar un directorio personal como `$HOME/bin` o `$HOME/.local/bin`. Asegúrate de que esté en tu `PATH`:
 
             ```bash
             mkdir -p $HOME/bin
-            mv kcli $HOME/bin/
+            mv eks-review $HOME/bin/
             export PATH="$HOME/bin:$PATH"
             ```
 
             Añade la línea anterior a tu `~/.bashrc` o `~/.zshrc` para que sea permanente.
 
     - **Windows:**
-        - Crea un directorio (ej. `C:\Program Files\kcli` o `C:\Users\TuUsuario\bin`).
-        - Mueve el archivo `kcli.exe` a ese directorio.
+        - Crea un directorio (ej. `C:\Program Files\eks-review` o `C:\Users\TuUsuario\bin`).
+        - Mueve el archivo `eks-review.exe` a ese directorio.
         - Añade ese directorio a tu variable de entorno `PATH` a través de las "Variables de Entorno" en las propiedades del sistema.
 
 3. **Verifica la instalación:**
@@ -57,7 +57,7 @@ Para ejecutar `kcli` desde cualquier lugar, el archivo ejecutable debe estar ubi
     Abre una nueva terminal y ejecuta:
 
     ```bash
-    kcli --help
+    eks-review --help
     ```
 
     Debería mostrar la ayuda de tu CLI.
@@ -86,25 +86,25 @@ El comando `go install` compila e instala paquetes. Los binarios se colocan en e
     go install
     ```
 
-    El nombre del binario será el del módulo o directorio principal. Si quieres que se llame `kcli`, es más directo usar la Opción A.
+    El nombre del binario será el del módulo o directorio principal. Si quieres que se llame `eks-review`, es más directo usar la Opción A.
 
 ---
 
 ### Opción C: Distribución a Otros Usuarios (Avanzado)
 
-Si deseas distribuir `kcli` a usuarios que no necesariamente tienen Go instalado:
+Si deseas distribuir `eks-review` a usuarios que no necesariamente tienen Go instalado:
 
 1. **Compilación Cruzada:**
 
     ```bash
     # Para Linux AMD64
-    GOOS=linux GOARCH=amd64 go build -o kcli_linux_amd64
+    GOOS=linux GOARCH=amd64 go build -o eks-review_linux_amd64
     # Para Windows AMD64
-    GOOS=windows GOARCH=amd64 go build -o kcli_windows_amd64.exe
+    GOOS=windows GOARCH=amd64 go build -o eks-review_windows_amd64.exe
     # Para macOS AMD64
-    GOOS=darwin GOARCH=amd64 go build -o kcli_darwin_amd64
+    GOOS=darwin GOARCH=amd64 go build -o eks-review_darwin_amd64
     # Para macOS ARM64 (Apple Silicon)
-    GOOS=darwin GOARCH=arm64 go build -o kcli_darwin_arm64
+    GOOS=darwin GOARCH=arm64 go build -o eks-review_darwin_arm64
     ```
 
 2. **Empaquetado:**
@@ -132,11 +132,11 @@ Para distribución más amplia, empieza con Releases de GitHub (Opción C.3) pro
 Puedes añadir una sección como esta en tu `README.md` principal:
 
 ```markdown
-## ⚙️ Instalación Avanzada (Acceso Global como `kcli`)
+## ⚙️ Instalación Avanzada (Acceso Global como `eks-review`)
 
-Por defecto, después de compilar con `go build -o kcli`, puedes ejecutar la herramienta desde el directorio del proyecto con `./kcli`.
+Por defecto, después de compilar con `go build -o eks-review`, puedes ejecutar la herramienta desde el directorio del proyecto con `./eks-review`.
 
-Si deseas poder ejecutar `kcli` desde cualquier ubicación en tu terminal, necesitarás instalar el binario en un directorio que esté en tu `PATH` del sistema.
+Si deseas poder ejecutar `eks-review` desde cualquier ubicación en tu terminal, necesitarás instalar el binario en un directorio que esté en tu `PATH` del sistema.
 
-Para instrucciones detalladas sobre cómo compilar con el nombre `kcli` e instalarlo globalmente en diferentes sistemas operativos, consulta nuestra [Guía de Instalación Avanzada](INSTALLATION_ADVANCED.md).
+Para instrucciones detalladas sobre cómo compilar con el nombre `eks-review` e instalarlo globalmente en diferentes sistemas operativos, consulta nuestra [Guía de Instalación Avanzada](INSTALLATION_ADVANCED.md).
 ```

--- a/README.md
+++ b/README.md
@@ -68,13 +68,13 @@ Para una lista completa y detallada de todos los comandos, sus subcomandos y tod
 
 ---
 
-## ⚙️ Instalación Avanzada (Acceso Global como `kcli`)
+## ⚙️ Instalación Avanzada (Acceso Global como `eks-review`)
 
-Por defecto, después de compilar con `go build -o kcli`, puedes ejecutar la herramienta desde el directorio del proyecto con `./kcli`.
+Por defecto, después de compilar con `go build -o eks-review`, puedes ejecutar la herramienta desde el directorio del proyecto con `./eks-review`.
 
-Si deseas poder ejecutar `kcli` desde cualquier ubicación en tu terminal, necesitarás instalar el binario en un directorio que esté en tu `PATH` del sistema.
+Si deseas poder ejecutar `eks-review` desde cualquier ubicación en tu terminal, necesitarás instalar el binario en un directorio que esté en tu `PATH` del sistema.
 
-Para instrucciones detalladas sobre cómo compilar con el nombre `kcli` e instalarlo globalmente en diferentes sistemas operativos, consulta nuestra [Guía de Instalación Avanzada](INSTALLATION_ADVANCED.md).
+Para instrucciones detalladas sobre cómo compilar con el nombre `eks-review` e instalarlo globalmente en diferentes sistemas operativos, consulta nuestra [Guía de Instalación Avanzada](INSTALLATION_ADVANCED.md).
 
 ---
 


### PR DESCRIPTION
## Summary
- pick `eks-review` as the primary binary
- update README and installation docs to use `eks-review` consistently

## Testing
- `go test ./...` *(fails: proxy blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685a1b02ee84832b9ff5dc004dd03a7f