### PR TITLE
Update README about network for go mod tidy/test

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,11 @@ go mod tidy
 
 Este comando descargará todas las librerías necesarias (Kubernetes client-go, Cobra, etc.).
 
+> **Nota:** Tanto `go mod tidy` como `go test` requieren acceso a internet para
+> descargar las dependencias. Ejecuta estos comandos en un entorno con
+> conectividad de red o asegúrate de que la caché de módulos de Go esté
+> pre-poblada.
+
 ### 3. Compilar la CLI
 
 ```bash


### PR DESCRIPTION
## Summary
- document that `go mod tidy` and `go test` need internet access
- advise running them on a networked environment or with a pre-filled Go module cache

## Testing
- `go test ./...` *(fails: cannot access proxy.golang.org)*

------
https://chatgpt.com/codex/tasks/task_e_685a1be34844832bb85c81c73c028896