### PR TITLE
Standardize binary name to eks-review

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# eks-review-cli
+# eks-review
 
 **Herramienta de Revisión de Clústeres de Kubernetes (EKS)**
 
@@ -6,7 +6,7 @@
 
 ## 📖 Visión General
 
-**eks-review-cli** es una herramienta de línea de comandos (CLI) escrita en Go, diseñada para simplificar la revisión y el diagnóstico de recursos en clústeres de Kubernetes, con un enfoque especial en Amazon EKS. Su objetivo es automatizar tareas repetitivas, estandarizar flujos de trabajo y proporcionar una visión rápida y clara del estado y la configuración de tus recursos de Kubernetes.
+**eks-review** es una herramienta de línea de comandos (CLI) escrita en Go, diseñada para simplificar la revisión y el diagnóstico de recursos en clústeres de Kubernetes, con un enfoque especial en Amazon EKS. Su objetivo es automatizar tareas repetitivas, estandarizar flujos de trabajo y proporcionar una visión rápida y clara del estado y la configuración de tus recursos de Kubernetes.
 
 La CLI ofrece un conjunto de comandos bajo `monitor` para obtener información detallada de varios recursos del clúster, visualizar eventos, acceder a logs y más.
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,8 +12,8 @@ var Verbose bool // Exportada para ser accesible por otros archivos del paquete 
 var rootCmd = &cobra.Command{
 	Use:   "eks-review",
 	Short: "Una herramienta CLI para revisar clústeres de EKS.",
-	Long: `eks-review-cli es una herramienta de línea de comandos (CLI) escrita en Go, 
-diseñada para simplificar la revisión y el diagnóstico de recursos en clústeres de Kubernetes, 
+	Long: `eks-review es una herramienta de línea de comandos (CLI) escrita en Go,
+diseñada para simplificar la revisión y el diagnóstico de recursos en clústeres de Kubernetes,
 con un enfoque especial en Amazon EKS.`,
 }
 


### PR DESCRIPTION
## Summary
- update README to refer to the CLI as **eks-review**
- tweak root command description to use the same name
- gofmt updated code

## Testing
- `go test ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685a1dbb5ba8832bbf161e5084257bb5