### PR TITLE
Clarify placeholder command descriptions

### DIFF
--- a/cmd/diagnose.go
+++ b/cmd/diagnose.go
@@ -9,13 +9,10 @@ import (
 // diagnoseCmd represents the diagnose command
 var diagnoseCmd = &cobra.Command{
 	Use:   "diagnose",
-	Short: "A brief description of your command",
-	Long: `A longer description that spans multiple lines and likely contains examples
-and usage of using your command. For example:
-
-Cobra is a CLI library for Go that empowers applications.
-This application is a tool to generate the needed files
-to quickly create a Cobra application.`,
+	Short: "Ejecuta chequeos de diagnóstico",
+	Long: `Realiza pruebas básicas en Pods, Services e Ingresses para
+detectar configuraciones erróneas o estados anómalos.
+Actualmente solo imprime un mensaje de prueba.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println("diagnose called")
 	},
@@ -23,14 +20,4 @@ to quickly create a Cobra application.`,
 
 func init() {
 	rootCmd.AddCommand(diagnoseCmd)
-
-	// Here you will define your flags and configuration settings.
-
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// diagnoseCmd.PersistentFlags().String("foo", "", "A help for foo")
-
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// diagnoseCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }

--- a/cmd/monitor.go
+++ b/cmd/monitor.go
@@ -9,13 +9,10 @@ import (
 // monitorCmd represents the monitor command
 var monitorCmd = &cobra.Command{
 	Use:   "monitor",
-	Short: "A brief description of your command",
-	Long: `A longer description that spans multiple lines and likely contains examples
-and usage of using your command. For example:
-
-Cobra is a CLI library for Go that empowers applications.
-This application is a tool to generate the needed files
-to quickly create a Cobra application.`,
+	Short: "Herramientas para inspeccionar el clúster",
+	Long: `Agrupa subcomandos orientados a observar el estado del clúster.
+Permite listar recursos, revisar eventos, acceder a logs y obtener
+resúmenes generales de la salud de Kubernetes.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println("monitor called")
 	},
@@ -23,14 +20,4 @@ to quickly create a Cobra application.`,
 
 func init() {
 	rootCmd.AddCommand(monitorCmd)
-
-	// Here you will define your flags and configuration settings.
-
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// monitorCmd.PersistentFlags().String("foo", "", "A help for foo")
-
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// monitorCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }

--- a/cmd/optimize.go
+++ b/cmd/optimize.go
@@ -9,13 +9,10 @@ import (
 // optimizeCmd represents the optimize command
 var optimizeCmd = &cobra.Command{
 	Use:   "optimize",
-	Short: "A brief description of your command",
-	Long: `A longer description that spans multiple lines and likely contains examples
-and usage of using your command. For example:
-
-Cobra is a CLI library for Go that empowers applications.
-This application is a tool to generate the needed files
-to quickly create a Cobra application.`,
+	Short: "Sugiere mejoras de rendimiento",
+	Long: `Identifica recursos sin uso o poco aprovechados y revisa la
+configuración de autoescalado para proponer ajustes que optimicen el
+consumo del clúster.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println("optimize called")
 	},
@@ -23,14 +20,4 @@ to quickly create a Cobra application.`,
 
 func init() {
 	rootCmd.AddCommand(optimizeCmd)
-
-	// Here you will define your flags and configuration settings.
-
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// optimizeCmd.PersistentFlags().String("foo", "", "A help for foo")
-
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// optimizeCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }

--- a/cmd/security.go
+++ b/cmd/security.go
@@ -9,13 +9,10 @@ import (
 // securityCmd represents the security command
 var securityCmd = &cobra.Command{
 	Use:   "security",
-	Short: "A brief description of your command",
-	Long: `A longer description that spans multiple lines and likely contains examples
-and usage of using your command. For example:
-
-Cobra is a CLI library for Go that empowers applications.
-This application is a tool to generate the needed files
-to quickly create a Cobra application.`,
+	Short: "Audita configuraciones de seguridad",
+	Long: `Evalúa Network Policies, reglas RBAC, imágenes de contenedores
+y Secrets para detectar posibles vulnerabilidades o malas prácticas.
+Actualmente es un comando placeholder sin funcionalidad completa.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println("security called")
 	},
@@ -23,14 +20,4 @@ to quickly create a Cobra application.`,
 
 func init() {
 	rootCmd.AddCommand(securityCmd)
-
-	// Here you will define your flags and configuration settings.
-
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// securityCmd.PersistentFlags().String("foo", "", "A help for foo")
-
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// securityCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }


### PR DESCRIPTION
## Summary
- update short and long help text for monitor, optimize, security and diagnose commands
- drop leftover init comments

## Testing
- `gofmt -w cmd/monitor.go cmd/optimize.go cmd/security.go cmd/diagnose.go`


------
https://chatgpt.com/codex/tasks/task_e_685ad9252518832bbed95a4643ba6259