### PR TITLE
Add local logos and update references

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -162,9 +162,9 @@ graph TD
 
 ## 🛠️ Included Tools
 
-[![kubectl](https://raw.githubusercontent.com/kubernetes/kubernetes/master/logo/logo.png)](https://kubernetes.io/docs/reference/kubectl/)
-[![Helm](https://raw.githubusercontent.com/helm/helm/main/docs/static/img/helm.svg)](https://helm.sh/)
-[![Docker](https://www.docker.com/wp-content/uploads/2022/03/Moby-logo.png)](https://www.docker.com/)
+[![kubectl](docs/assets/kubectl.svg)](https://kubernetes.io/docs/reference/kubectl/)
+[![Helm](docs/assets/helm.svg)](https://helm.sh/)
+[![Docker](docs/assets/docker.svg)](https://www.docker.com/)
 
 - [kubectl](https://kubernetes.io/docs/reference/kubectl/)
 - [Helm](https://helm.sh/)

--- a/README.md
+++ b/README.md
@@ -164,9 +164,9 @@ graph TD
 
 ## 🛠️ Herramientas Incluidas
 
-[![kubectl](https://raw.githubusercontent.com/kubernetes/kubernetes/master/logo/logo.png)](https://kubernetes.io/docs/reference/kubectl/)
-[![Helm](https://raw.githubusercontent.com/helm/helm/main/docs/static/img/helm.svg)](https://helm.sh/)
-[![Docker](https://www.docker.com/wp-content/uploads/2022/03/Moby-logo.png)](https://www.docker.com/)
+[![kubectl](docs/assets/kubectl.svg)](https://kubernetes.io/docs/reference/kubectl/)
+[![Helm](docs/assets/helm.svg)](https://helm.sh/)
+[![Docker](docs/assets/docker.svg)](https://www.docker.com/)
 
 - [kubectl](https://kubernetes.io/docs/reference/kubectl/)
 - [Helm](https://helm.sh/)

--- a/docs/assets/docker.svg
+++ b/docs/assets/docker.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="50">
+  <rect width="100" height="50" fill="#0db7ed"/>
+  <text x="50" y="30" font-size="20" text-anchor="middle" fill="white" font-family="Arial">Docker</text>
+</svg>

--- a/docs/assets/helm.svg
+++ b/docs/assets/helm.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="50">
+  <rect width="100" height="50" fill="#277A9B"/>
+  <text x="50" y="30" font-size="20" text-anchor="middle" fill="white" font-family="Arial">Helm</text>
+</svg>

--- a/docs/assets/kubectl.svg
+++ b/docs/assets/kubectl.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="50">
+  <rect width="100" height="50" fill="#326CE5"/>
+  <text x="50" y="30" font-size="20" text-anchor="middle" fill="white" font-family="Arial">kubectl</text>
+</svg>


### PR DESCRIPTION
## Summary
- add placeholder kubectl, Helm, and Docker logos under `docs/assets`
- update README files to reference the local images

## Testing
- `go test ./...` *(fails: forbidden to fetch modules)*

------
https://chatgpt.com/codex/tasks/task_e_685afb799924832b9c8386227e6666e8