### PR TITLE
Refactor kube client initialization

### DIFF
--- a/cmd/events.go
+++ b/cmd/events.go
@@ -21,7 +21,11 @@ var eventsCmd = &cobra.Command{
 	Long: `El comando events recupera y muestra eventos recientes de Kubernetes,
 útiles para la resolución de problemas. Puedes filtrar por tipo (Warning, Normal) y namespace.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		clients := GetKubeClients() // Llama a la versión que sale en error
+		clients, err := GetKubeClients()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error creando clientes de Kubernetes: %v\n", err)
+			os.Exit(1)
+		}
 
 		fmt.Fprintln(os.Stdout, "Recuperando eventos de Kubernetes...")
 

--- a/cmd/get_cronjobs.go
+++ b/cmd/get_cronjobs.go
@@ -26,7 +26,10 @@ var cronjobsGetCmd = &cobra.Command{
 	Aliases: []string{"cj"},
 	Short:   "Lista uno o más cronjobs",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		clients := GetKubeClients()
+		clients, err := GetKubeClients()
+		if err != nil {
+			return fmt.Errorf("creando clientes de Kubernetes: %w", err)
+		}
 		// CronJobs no son filtrables por label selector directamente a nivel de lista de CronJob,
 		// pero lo mantenemos por consistencia si se implementa un filtro custom.
 		listOptions := metav1.ListOptions{LabelSelector: cronjobsSelector}
@@ -37,7 +40,6 @@ var cronjobsGetCmd = &cobra.Command{
 
 		var cjList *batchv1.CronJobList
 		var singleCJ *batchv1.CronJob
-		var err error
 
 		if len(args) > 0 {
 			cjName := args[0]

--- a/cmd/get_daemonsets.go
+++ b/cmd/get_daemonsets.go
@@ -27,7 +27,10 @@ var daemonsetsGetCmd = &cobra.Command{
 	Short:   "Lista uno o más daemonsets",
 	Long:    `Lista uno o más daemonsets en el namespace actual o en todos los namespaces.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		clients := GetKubeClients()
+		clients, err := GetKubeClients()
+		if err != nil {
+			return fmt.Errorf("creando clientes de Kubernetes: %w", err)
+		}
 		listOptions := metav1.ListOptions{LabelSelector: daemonsetsSelector}
 		effectiveNamespace := GetEffectiveNamespace(daemonsetsNamespace, daemonsetsAllNamespaces, "default", false)
 		if daemonsetsAllNamespaces {
@@ -36,7 +39,6 @@ var daemonsetsGetCmd = &cobra.Command{
 
 		var dsList *appsv1.DaemonSetList
 		var singleDS *appsv1.DaemonSet
-		var err error
 
 		if len(args) > 0 {
 			dsName := args[0]

--- a/cmd/get_jobs.go
+++ b/cmd/get_jobs.go
@@ -28,7 +28,10 @@ var jobsGetCmd = &cobra.Command{
 	Short:   "Lista uno o más jobs",
 	Long:    `Lista uno o más jobs en el namespace actual o en todos los namespaces.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		clients := GetKubeClients()
+		clients, err := GetKubeClients()
+		if err != nil {
+			return fmt.Errorf("creando clientes de Kubernetes: %w", err)
+		}
 		listOptions := metav1.ListOptions{LabelSelector: jobsSelector}
 		effectiveNamespace := GetEffectiveNamespace(jobsNamespace, jobsAllNamespaces, "default", false)
 		if jobsAllNamespaces {
@@ -37,7 +40,6 @@ var jobsGetCmd = &cobra.Command{
 
 		var jobList *batchv1.JobList
 		var singleJob *batchv1.Job
-		var err error
 
 		if len(args) > 0 { // Si se especifica un nombre de job
 			jobName := args[0]

--- a/cmd/get_namespaces.go
+++ b/cmd/get_namespaces.go
@@ -25,12 +25,14 @@ var namespacesGetCmd = &cobra.Command{
 	Aliases: []string{"ns"},
 	Short:   "Lista uno o más namespaces",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		clients := GetKubeClients()
+		clients, err := GetKubeClients()
+		if err != nil {
+			return fmt.Errorf("creando clientes de Kubernetes: %w", err)
+		}
 		listOptions := metav1.ListOptions{LabelSelector: namespacesSelector}
 
 		var nsList *corev1.NamespaceList
 		var singleNS *corev1.Namespace
-		var err error
 
 		if len(args) > 0 {
 			nsName := args[0]

--- a/cmd/get_pods.go
+++ b/cmd/get_pods.go
@@ -30,7 +30,10 @@ var podsGetCmd = &cobra.Command{
 	Long: `Lista uno o más pods en el namespace actual o en todos los namespaces.
 Puedes especificar un nombre de pod opcional para listar solo ese pod.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		clients := GetKubeClients() // Obtiene clientes, maneja os.Exit en error
+		clients, err := GetKubeClients()
+		if err != nil {
+			return fmt.Errorf("creando clientes de Kubernetes: %w", err)
+		}
 
 		listOptions := metav1.ListOptions{
 			LabelSelector: podsSelector,
@@ -45,7 +48,6 @@ Puedes especificar un nombre de pod opcional para listar solo ese pod.`,
 
 		var podList *corev1.PodList
 		var singlePod *corev1.Pod
-		var err error
 
 		if len(args) > 0 { // Si se especifica un nombre de pod
 			podName := args[0]

--- a/cmd/get_serviceaccounts.go
+++ b/cmd/get_serviceaccounts.go
@@ -26,7 +26,10 @@ var serviceaccountsGetCmd = &cobra.Command{
 	Aliases: []string{"sa"},
 	Short:   "Lista uno o más serviceaccounts",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		clients := GetKubeClients()
+		clients, err := GetKubeClients()
+		if err != nil {
+			return fmt.Errorf("creando clientes de Kubernetes: %w", err)
+		}
 		listOptions := metav1.ListOptions{LabelSelector: saSelector}
 		effectiveNamespace := GetEffectiveNamespace(saNamespace, saAllNamespaces, "default", false)
 		if saAllNamespaces {
@@ -35,7 +38,6 @@ var serviceaccountsGetCmd = &cobra.Command{
 
 		var saList *corev1.ServiceAccountList
 		var singleSA *corev1.ServiceAccount
-		var err error
 
 		if len(args) > 0 {
 			saName := args[0]

--- a/cmd/get_services.go
+++ b/cmd/get_services.go
@@ -27,7 +27,10 @@ var servicesGetCmd = &cobra.Command{
 	Short:   "Lista uno o más services",
 	Long:    `Lista uno o más services en el namespace actual o en todos los namespaces.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		clients := GetKubeClients()
+		clients, err := GetKubeClients()
+		if err != nil {
+			return fmt.Errorf("creando clientes de Kubernetes: %w", err)
+		}
 		listOptions := metav1.ListOptions{LabelSelector: servicesSelector}
 		effectiveNamespace := GetEffectiveNamespace(servicesNamespace, servicesAllNamespaces, "default", false)
 		if servicesAllNamespaces {
@@ -36,7 +39,6 @@ var servicesGetCmd = &cobra.Command{
 
 		var serviceList *corev1.ServiceList
 		var singleService *corev1.Service
-		var err error
 
 		if len(args) > 0 {
 			serviceName := args[0]

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -31,7 +31,11 @@ var logsCmd = &cobra.Command{
 	Long: `Imprime los logs de un contenedor en un pod, deployment o servicio.
 ...(ejemplos)...`,
 	Run: func(cmd *cobra.Command, args []string) {
-		clients := GetKubeClients() // Llama a la versión que sale en error
+		clients, err := GetKubeClients()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error creando clientes de Kubernetes: %v\n", err)
+			os.Exit(1)
+		}
 
 		effectiveLogNamespace := GetEffectiveNamespace(logNamespace, false, "default", false)
 

--- a/cmd/nodes.go
+++ b/cmd/nodes.go
@@ -19,7 +19,11 @@ var nodesCmd = &cobra.Command{
 los nodos del clúster de Kubernetes, incluyendo su estado, roles y uso de recursos.
 El uso de recursos requiere un servidor de métricas instalado en el clúster.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		clients := GetKubeClients() // Llama a la versión que sale en error
+		clients, err := GetKubeClients()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error creando clientes de Kubernetes: %v\n", err)
+			os.Exit(1)
+		}
 
 		fmt.Fprintln(os.Stdout, "Recuperando información de nodos de Kubernetes...")
 

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -22,7 +22,11 @@ var statusCmd = &cobra.Command{
 	Long: `El comando status recupera un resumen de Pods, Deployments, Services,
 e Ingresses en un namespace dado o en todos los namespaces.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		clients := GetKubeClients() // Llama a la versión que sale en error
+		clients, err := GetKubeClients()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error creando clientes de Kubernetes: %v\n", err)
+			os.Exit(1)
+		}
 
 		fmt.Println("Recuperando estado de recursos de Kubernetes...")
 		namespaceToList := GetEffectiveNamespace(targetNamespace, allNamespaces, "default", false)


### PR DESCRIPTION
## Summary
- return an error from `GetKubeClients` instead of exiting
- update commands to handle the new error

## Testing
- `go test ./...` *(fails: forbidden access to proxy)*
- `go vet ./...` *(fails: forbidden access to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685b05b8f8e4832baf64ccf5510e8c88